### PR TITLE
Wrapping up dispatch execution feature

### DIFF
--- a/src/cait/cortic_webapp/static/js/cait_blocks.js
+++ b/src/cait/cortic_webapp/static/js/cait_blocks.js
@@ -1462,24 +1462,68 @@ Blockly.Python['set_parameter'] = function (block) {
 
 Blockly.JavaScript['dispatch_block'] = function (block) {
   var statements_operation = Blockly.JavaScript.statementToCode(block, 'dispatch_blocks');
-  all_statements = [];
+  // var func_list = [];
+
+  // var all_functions = Blockly.Procedures.allProcedures(workspace);
+  // for (var f in all_functions) {
+  //   for (var p in all_functions[f]) {
+  //     func_list.push(all_functions[f][p][0]);
+  //   }
+  // }
+  // func_code = "";
+
+  // for (var i in func_list) {
+  //   var headless = new Blockly.Workspace();
+  //   var xml = Blockly.Xml.workspaceToDom(headless);
+    //var func_xml = Blockly.Xml.blockToDom(Blockly.Procedures.getDefinition(func_list[i], workspace)).cloneNode(true);
+    //xml.appendChild(func_xml);
+    //Blockly.Xml.domToWorkspace(xml, headless);
+
+    //this_code = Blockly.JavaScript.workspaceToCode(headless);
+    // this_code = replaceAll(this_code, 'function', 'async function');
+    // for (var j in func_list) {
+    //   if (func_list[j] != func_list[i]) {
+    //     if (this_code.indexOf(func_list[j]) != -1) {
+    //       this_code = replaceAll(this_code, func_list[j], "await " + func_list[j]);
+    //     }
+    //   }
+    // }
+    // func_code = func_code + this_code;
+  // }
+
+  // func_statments = []
+  // var stop_index = func_code.indexOf("\n");
+  // func_statments.push(func_code.substring(0, stop_index));
+  // var start_index = stop_index;
+  // stop_index = func_code.indexOf("\n", start_index + 1);
+  // while (stop_index != -1) {
+  //   func_statments.push(func_code.substring(start_index + 1, stop_index));
+  //   start_index = stop_index;
+  //   stop_index = func_code.indexOf("\n", start_index + 1);
+  // }
+  all_statements = ["// Start of runtime code"];
   stop_index = statements_operation.indexOf("\n");
-  all_statements.push(statements_operation.substring(2, stop_index))
+  all_statements.push(statements_operation.substring(2, stop_index));
   var start_index = stop_index;
   stop_index = statements_operation.indexOf("\n", start_index + 1);
   while (stop_index != -1) {
-    all_statements.push(statements_operation.substring(start_index + 3, stop_index))
-    start_index = stop_index
+    all_statements.push(statements_operation.substring(start_index + 3, stop_index));
+    start_index = stop_index;
     //statements_main = statements_main.substring(0, index + 1) + statements_main.substring(index + 3, statements_main.length);
     stop_index = statements_operation.indexOf("\n", start_index + 1);
   }
+
+  // all_statements = func_statments.concat(all_statements);
+
   var statements_operation = '';
   for (var i in all_statements) {
     this_statement = all_statements[i];
-    if (this_statement.indexOf("highlightBlock") == -1) {
-      statements_operation = statements_operation + this_statement + '\\n';
-
-    }
+    // if (this_statement.indexOf("highlightBlock") != -1) {
+    //   //statements_operation = statements_operation + this_statement + '\\n';
+    //   this_statement = this_statement.substring(0, this_statement.length - 2) + ', false);';
+    //   //console.log(this_statement.substring(0, this_statement.length - 2) + ', true);');
+    // }
+    statements_operation = statements_operation + this_statement + '\\n';
   }
   all_used_vars = []
   var this_block = block;

--- a/src/cait/cortic_webapp/static/js/cait_blocks.js
+++ b/src/cait/cortic_webapp/static/js/cait_blocks.js
@@ -1460,47 +1460,9 @@ Blockly.Python['set_parameter'] = function (block) {
   return code;
 };
 
+
 Blockly.JavaScript['dispatch_block'] = function (block) {
   var statements_operation = Blockly.JavaScript.statementToCode(block, 'dispatch_blocks');
-  // var func_list = [];
-
-  // var all_functions = Blockly.Procedures.allProcedures(workspace);
-  // for (var f in all_functions) {
-  //   for (var p in all_functions[f]) {
-  //     func_list.push(all_functions[f][p][0]);
-  //   }
-  // }
-  // func_code = "";
-
-  // for (var i in func_list) {
-  //   var headless = new Blockly.Workspace();
-  //   var xml = Blockly.Xml.workspaceToDom(headless);
-    //var func_xml = Blockly.Xml.blockToDom(Blockly.Procedures.getDefinition(func_list[i], workspace)).cloneNode(true);
-    //xml.appendChild(func_xml);
-    //Blockly.Xml.domToWorkspace(xml, headless);
-
-    //this_code = Blockly.JavaScript.workspaceToCode(headless);
-    // this_code = replaceAll(this_code, 'function', 'async function');
-    // for (var j in func_list) {
-    //   if (func_list[j] != func_list[i]) {
-    //     if (this_code.indexOf(func_list[j]) != -1) {
-    //       this_code = replaceAll(this_code, func_list[j], "await " + func_list[j]);
-    //     }
-    //   }
-    // }
-    // func_code = func_code + this_code;
-  // }
-
-  // func_statments = []
-  // var stop_index = func_code.indexOf("\n");
-  // func_statments.push(func_code.substring(0, stop_index));
-  // var start_index = stop_index;
-  // stop_index = func_code.indexOf("\n", start_index + 1);
-  // while (stop_index != -1) {
-  //   func_statments.push(func_code.substring(start_index + 1, stop_index));
-  //   start_index = stop_index;
-  //   stop_index = func_code.indexOf("\n", start_index + 1);
-  // }
   all_statements = ["// Start of runtime code"];
   stop_index = statements_operation.indexOf("\n");
   all_statements.push(statements_operation.substring(2, stop_index));
@@ -1512,8 +1474,6 @@ Blockly.JavaScript['dispatch_block'] = function (block) {
     //statements_main = statements_main.substring(0, index + 1) + statements_main.substring(index + 3, statements_main.length);
     stop_index = statements_operation.indexOf("\n", start_index + 1);
   }
-
-  // all_statements = func_statments.concat(all_statements);
 
   var statements_operation = '';
   for (var i in all_statements) {

--- a/src/cait/cortic_webapp/static/js/cait_functions.js
+++ b/src/cait/cortic_webapp/static/js/cait_functions.js
@@ -43,7 +43,7 @@ function dispatch_to(dispatch_queue, operations, var_list = {}) {
       var stop_index = loc + key.length;
       if (operation_statement[stop_index].match(alphanumeric) == null) {
         if (operation_statement[start_index - 1] != "_" & operation_statement[stop_index] != "_") {
-          console.log(key + ", " + operation_statement[stop_index])
+          //console.log(key + ", " + operation_statement[stop_index])
           if (operation_statement.substring(start_index - 14, start_index) != "set_main_var('") {
             var val = var_list[key]
             if (typeof (var_list[key]) == "string") {
@@ -71,7 +71,7 @@ function dispatch_to(dispatch_queue, operations, var_list = {}) {
       loc = operation_statement.indexOf(key, stop_index);
     }
   }
-  console.log(operation_statement)
+  //console.log(operation_statement)
 
   var dispatch_code = 'execute_operations("' + operation_statement + '");';
   // if (dispatch_queue == "queue_1") {

--- a/src/cait/cortic_webapp/static/js/cait_functions.js
+++ b/src/cait/cortic_webapp/static/js/cait_functions.js
@@ -35,43 +35,45 @@ const alphanumeric = /^[\p{sc=Latn}\p{Nd}]+$/u;
 
 function dispatch_to(dispatch_queue, operations, var_list = {}) {
   operation_statement = operations.replace(/\n/g, "\\n");
-  var replaced_statement = operation_statement;
-  console.log(var_list);
+  var init_index = operation_statement.indexOf("// Start of runtime code");
   for (var key in var_list) {
-    var loc = operation_statement.indexOf(key);
+    var loc = operation_statement.indexOf(key, init_index);
     while (loc != -1) {
       var start_index = loc;
       var stop_index = loc + key.length;
       if (operation_statement[stop_index].match(alphanumeric) == null) {
-        if (operation_statement.substring(start_index - 14, start_index) != "set_main_var('") {
-          var val = var_list[key]
-          if (typeof (var_list[key]) == "string") {
-            val = "'" + val + "'";
-          }
-          else if (typeof (var_list[key]) == "object") {
-            if (Array.isArray(var_list[key])) {
-              for (var i in val) {
-                if (typeof (val[i]) == "string") {
-                  if (val[i][0] != "'") {
-                    val[i] = "'" + val[i] + "'";
+        if (operation_statement[start_index - 1] != "_" & operation_statement[stop_index] != "_") {
+          console.log(key + ", " + operation_statement[stop_index])
+          if (operation_statement.substring(start_index - 14, start_index) != "set_main_var('") {
+            var val = var_list[key]
+            if (typeof (var_list[key]) == "string") {
+              val = "'" + val + "'";
+            }
+            else if (typeof (var_list[key]) == "object") {
+              if (Array.isArray(var_list[key])) {
+                for (var i in val) {
+                  if (typeof (val[i]) == "string") {
+                    if (val[i][0] != "'") {
+                      val[i] = "'" + val[i] + "'";
+                    }
                   }
                 }
+                val = "[" + val + "]";
               }
-              val = "[" + val + "]";
             }
+            else {
+              val = String(val);
+            }
+            operation_statement = operation_statement.substring(0, start_index) + val + operation_statement.substring(stop_index, operation_statement.length);
           }
-          else {
-            val = String(val);
-          }
-          replaced_statement = replaced_statement.substring(0, start_index) + val + replaced_statement.substring(stop_index, replaced_statement.length);
         }
       }
       loc = operation_statement.indexOf(key, stop_index);
     }
   }
-  console.log(replaced_statement)
+  console.log(operation_statement)
 
-  var dispatch_code = 'execute_operations("' + replaced_statement + '");';
+  var dispatch_code = 'execute_operations("' + operation_statement + '");';
   // if (dispatch_queue == "queue_1") {
   //   if (task_queue_1.length == 0) {
 

--- a/src/cait/cortic_webapp/static/js/version.js
+++ b/src/cait/cortic_webapp/static/js/version.js
@@ -1,1 +1,1 @@
-var VERSION = "1.6"
+var VERSION = "1.7"

--- a/src/cait/cortic_webapp/static/js/workspace_utils.js
+++ b/src/cait/cortic_webapp/static/js/workspace_utils.js
@@ -514,7 +514,18 @@ function updateFunction(event) {
 var stopCode = false;
 
 function highlightBlock(id) {
-  workspace.highlightBlock(id);
+  //workspace.highlightBlock(id);
+  var blk = workspace.getBlockById(id);
+  if (blk.type != "main_block") {
+    workspace.getBlockById(id).addSelect();
+  }
+}
+
+function de_highlightBlock(id) {
+  var blk = workspace.getBlockById(id);
+  if (blk.type != "main_block") {
+    workspace.getBlockById(id).removeSelect();
+  }
 }
 
 function resetStepUi(clearOutput) {
@@ -529,6 +540,8 @@ function run_code() {
   Blockly.JavaScript.addReservedWords('code');
   Blockly.JavaScript.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
   Blockly.JavaScript.addReservedWords('highlightBlock');
+  Blockly.JavaScript.STATEMENT_SUFFIX = 'de_highlightBlock(%1);\n';
+  Blockly.JavaScript.addReservedWords('de_highlightBlock');
   resetStepUi(true);
   try {
     var code = Blockly.JavaScript.workspaceToCode(workspace);

--- a/src/cait/cortic_webapp/static/js/workspace_utils.js
+++ b/src/cait/cortic_webapp/static/js/workspace_utils.js
@@ -560,6 +560,23 @@ function run_code() {
         runtime_code = replaceAll(runtime_code, async_function[f], "await " + async_function[f]);
       }
       code = code.substring(0, init_idx) + runtime_code;
+      var func_code = code.substring(0, code.indexOf("// Initialize and setup different components"));
+      var func_statements = [];
+      var stop_index = func_code.indexOf("\n");
+      func_statements.push(func_code.substring(0, stop_index));
+      var start_index = stop_index;
+      stop_index = func_code.indexOf("\n", start_index + 1);
+      while (stop_index != -1) {
+        func_statements.push(func_code.substring(start_index + 1, stop_index));
+        start_index = stop_index;
+        //statements_main = statements_main.substring(0, index + 1) + statements_main.substring(index + 3, statements_main.length);
+        stop_index = func_code.indexOf("\n", start_index + 1);
+      }
+      func_code = '';
+      for (var i in func_statements) {
+        this_statement = func_statements[i];
+        func_code = func_code + this_statement + '\\n';
+      }
       code = code + "\n resetStepUi(true);\n"
       code = "(async () => {" + code + "})();";
     }
@@ -567,14 +584,17 @@ function run_code() {
     dispatch_index = code.indexOf("dispatch_to");
     var start_index = code.indexOf(', "', dispatch_index);
     var stop_index = code.indexOf('\\n"', start_index);
-    var dispatch_code = code.substring(start_index + 2, stop_index + 3);
+    var dispatch_code = code.substring(start_index + 3, stop_index);
 
-    dispatch_index = code.indexOf("dispatch_to", stop_index);
+    code = code.substring(0, start_index + 3) + func_code + dispatch_code + code.substring(stop_index, code.length);
+
+    dispatch_index = code.indexOf("dispatch_to", stop_index + func_code.length);
     while (dispatch_index != -1) {
       start_index = code.indexOf(', "', stop_index);
       stop_index = code.indexOf('\\n"', start_index);
-      dispatch_code = code.substring(start_index + 2, stop_index + 3);
-      dispatch_index = code.indexOf("dispatch_to", stop_index);
+      dispatch_code = code.substring(start_index + 2, stop_index);
+      code = code.substring(0, start_index + 3) + func_code + dispatch_code + code.substring(stop_index, code.length);
+      dispatch_index = code.indexOf("dispatch_to", stop_index + func_code.length);
     }
 
     var ready_to_execute_code = true;

--- a/src/cait/cortic_webapp/static/js/workspace_utils.js
+++ b/src/cait/cortic_webapp/static/js/workspace_utils.js
@@ -516,14 +516,14 @@ var stopCode = false;
 function highlightBlock(id) {
   //workspace.highlightBlock(id);
   var blk = workspace.getBlockById(id);
-  if (blk.type != "main_block") {
+  if (blk.type != "main_block" & blk.type != "processing_block") {
     workspace.getBlockById(id).addSelect();
   }
 }
 
 function de_highlightBlock(id) {
   var blk = workspace.getBlockById(id);
-  if (blk.type != "main_block") {
+  if (blk.type != "main_block" & blk.type != "processing_block") {
     workspace.getBlockById(id).removeSelect();
   }
 }
@@ -594,20 +594,23 @@ function run_code() {
       code = "(async () => {" + code + "})();";
     }
 
+
     dispatch_index = code.indexOf("dispatch_to");
-    var start_index = code.indexOf(', "', dispatch_index);
-    var stop_index = code.indexOf('\\n"', start_index);
-    var dispatch_code = code.substring(start_index + 3, stop_index);
+    if (dispatch_index != -1) {
+      var start_index = code.indexOf(', "', dispatch_index);
+      var stop_index = code.indexOf('\\n"', start_index);
+      var dispatch_code = code.substring(start_index + 3, stop_index);
 
-    code = code.substring(0, start_index + 3) + func_code + dispatch_code + code.substring(stop_index, code.length);
-
-    dispatch_index = code.indexOf("dispatch_to", stop_index + func_code.length);
-    while (dispatch_index != -1) {
-      start_index = code.indexOf(', "', stop_index);
-      stop_index = code.indexOf('\\n"', start_index);
-      dispatch_code = code.substring(start_index + 2, stop_index);
       code = code.substring(0, start_index + 3) + func_code + dispatch_code + code.substring(stop_index, code.length);
+
       dispatch_index = code.indexOf("dispatch_to", stop_index + func_code.length);
+      while (dispatch_index != -1) {
+        start_index = code.indexOf(', "', stop_index);
+        stop_index = code.indexOf('\\n"', start_index);
+        dispatch_code = code.substring(start_index + 2, stop_index);
+        code = code.substring(0, start_index + 3) + func_code + dispatch_code + code.substring(stop_index, code.length);
+        dispatch_index = code.indexOf("dispatch_to", stop_index + func_code.length);
+      }
     }
 
     var ready_to_execute_code = true;


### PR DESCRIPTION
In this merge, two issues are being fixed for the dispatch execution feature:

1. When users define their own functions in the workspace, these functions cannot be used in the dispatch block. This was because the function definition only exists in the main program, so the program executed in the dispatch block does not know how to call such functions. This is fixed by first parsing the full definition of these user-defined functions, then passing in the full definition of these functions into the dispatch block as part of the program. 
2. When the programs in the dispatch block are being executed, there were no block highlightings on those programs. This is fixed by using Blockly.JavaScript.STATEMENT_PREFIX and Blockly.JavaScript.STATEMENT_SUFFIX to add a highlight and dehighlight statement before and after a block is executed. This way, both programs within the main block and programs within the dispatch can be highlighted during execution.